### PR TITLE
docs: update Dockerfile path references after layout refactor

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -14,8 +14,8 @@ dockerfiles/
 
 | Dockerfile | Image tag | Role |
 |---|---|---|
-| `Dockerfile.v022-d568` | `v022-d568` | Forward-stack validation base (NGC 26.04 + vLLM 0.21.0 + SM121 FP8 cherry-pick). General-purpose base for non-DSV4 model presets. **On GHCR.** |
-| `Dockerfile.dsv4-d568` | `dsv4-d568` | Primary DeepSeek-V4-Flash image path. `FROM v022-d568` + SM12x DSV4 vLLM patches (sparse MLA, Lightning Indexer, fp8_ds_mla KV, MTP). **On GHCR. Currently frozen — do not update casually.** |
+| `dockerfiles/active/Dockerfile.v022-d568` | `v022-d568` | Forward-stack validation base (NGC 26.04 + vLLM 0.21.0 + SM121 FP8 cherry-pick). General-purpose base for non-DSV4 model presets. **On GHCR.** |
+| `dockerfiles/active/Dockerfile.dsv4-d568` | `dsv4-d568` | Primary DeepSeek-V4-Flash image path. `FROM v022-d568` + SM12x DSV4 vLLM patches (sparse MLA, Lightning Indexer, fp8_ds_mla KV, MTP). **On GHCR. Currently frozen — do not update casually.** |
 
 Build commands (always build from **repo root** with `.` as context):
 

--- a/dockerfiles/active/Dockerfile.v022-d568
+++ b/dockerfiles/active/Dockerfile.v022-d568
@@ -64,7 +64,7 @@
 #   - flashinfer_cache.patch        (FlashInfer build-time, optional)
 #
 # Build:
-#   docker buildx build -f Dockerfile.v022-d568 \
+#   docker buildx build -f dockerfiles/active/Dockerfile.v022-d568 \
 #     -t ghcr.io/bjk110/vllm-spark:v022-d568 --load .
 #
 # Verify:


### PR DESCRIPTION
## Summary

Cosmetic follow-up to Stage 3-B (#5). Two stale path references left after the Dockerfile layout refactor:

- `dockerfiles/active/Dockerfile.v022-d568`: build comment now shows `-f dockerfiles/active/Dockerfile.v022-d568` (was bare filename)
- `dockerfiles/README.md`: active-targets table now shows full `dockerfiles/active/...` paths instead of bare filenames

## Test plan

- [x] Dockerfile change is comment-only — no instructions modified
- [x] `dockerfiles/README.md` table and build commands consistent (full paths throughout)
- [x] `docker buildx build -f dockerfiles/active/Dockerfile.v022-d568 --target __nonexistent_target__` parses without errors
- [x] No runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)