### PR TITLE
docs: move image tag management notes out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,58 +716,20 @@ memory pressure):
 4. Only if the above still fails: consider a TP=2 variant across both Spark
    nodes (no preset ships for this — this experimental preset is TP=1 only).
 
-## Image tags & Git tags
+## Container images
 
-GHCR image tags (`ghcr.io/bjk110/vllm-spark:<tag>`) and Git tags do **not**
-march in lockstep yet — only `v018-ngc2603` exists as a Git tag. The mapping
-below documents what each image tag corresponds to in the Git history. Use
-this table when you need to reproduce or roll back to a specific image.
+The current recommended serving paths are:
 
-| Image tag | Git ref (commit) | Stack | Notes |
-|---|---|---|---|
-| `dsv4-d568` (active, DSV4-specific) | current HEAD | `FROM v022-d568` + SM12x DSV4 vLLM patches | DeepSeek-V4-Flash primary path; used only by `presets/dsv4-flash-fp8-tp2.env`. See [`docs/dsv4-flash-tp2.md`](docs/dsv4-flash-tp2.md). |
-| `v022-d568` (active, general base) | current HEAD | NGC 26.04 + vLLM 0.21.0+PR#35568 + FlashInfer 0.6.11.post3 + Triton 3.7.0 + NCCL 2.30.4 + Transformers 5.8.1 | General production base for v022-series presets and the dsv4-d568 derivative. |
-| `v021-tq` | `3070f9a` | base + TQ patches + Inductor-graph-partition fix | Required for any `*-tq.env` preset (production default for TurboQuant presets). |
-| `v021-ngc2603` | `8623187` | vLLM `95995bbe` + FlashInfer `v0.6.9` | Production default for non-TQ presets (most `presets/*.env` files reference this). |
-| `v020-ngc2603` (superseded) | `8efdf0b` (base-refresh-20260417 base bump) | vLLM `978a4462` + FlashInfer `v0.6.8` | Superseded by v021; only kept on GHCR for historical reproduction. |
-| `v019-ngc2603` (superseded) | `7736716` (Gemma 4 + vLLM 0.19.1 upgrade) | vLLM `0.19.1` `a7d79fa` + FlashInfer `v0.6.7.post3` | Superseded by v021. |
-| `v018-ngc2603` (archive) | `feb5993` (NGC 26.03 source build intro) — Git tag `v018-ngc2603` exists | vLLM `0.18.3` `c494977` + FlashInfer `v0.6.7` | The only currently-tagged release in Git. |
+| Path | Status | Config |
+|---|---|---|
+| `dsv4-d568` | Frozen primary DeepSeek-V4-Flash baseline | `presets/dsv4-flash-fp8-tp2.env` |
+| `unholy-fusion` | Experimental high-prefill path | `.env.unholy-fusion` + `compose/docker-compose.unholy.yml` |
 
-### Recommended Git tags to create
+Older image tags, Git commit mappings, and image history are documented in
+[`docs/images.md`](docs/images.md).
 
-Only `v018-ngc2603` is currently tagged. The maintainer can create the
-following tags to align Git tags with GHCR image tags. Run from a clean
-checkout of `main`; do **not** run blindly — verify the SHAs first.
-
-    git tag -a v019-ngc2603 7736716 -m "v019-ngc2603 — Gemma 4 + vLLM 0.19.1"
-    git tag -a v020-ngc2603 8efdf0b -m "v020-ngc2603 — base-refresh-20260417 (vLLM 978a4462, FlashInfer 0.6.8)"
-    git tag -a v021-ngc2603 8623187 -m "v021-ngc2603 — vLLM 95995bbe + FlashInfer v0.6.9"
-    git tag -a v021-tq      3070f9a -m "v021-tq — base + TurboQuant cherry-picks + codegen workaround"
-    git push origin v019-ngc2603 v020-ngc2603 v021-ngc2603 v021-tq
-
-**Verify commit before tagging.** The four SHAs above were extracted from
-`git log --oneline` at the time this README was last updated; if subsequent
-work reshuffles `main`, re-locate the boundary commits with:
-
-    git log --oneline --grep='base.refresh\|bump base.*v021\|0.19.1\|use Inductor graph partition'
-
-## Branch structure
-
-`main` is the only long-lived branch. All previously separate work
-streams (base stack refresh, TurboQuant rebase, single-Spark CLUSTER_MODE,
-unholy-fusion integration) have been merged in and their feature branches deleted.
-
-### Archived branch history
-
-The legacy TurboQuant branch is preserved as a tag for reference:
-
-- **`archive/feat-turboquant`**
-
-If needed, it can be restored with:
-
-```bash
-git checkout -b feat/turboquant archive/feat-turboquant
-```
+Maintainer-only Git tag and archived branch notes are documented in
+[`docs/release-management.md`](docs/release-management.md).
 
 ## License
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,42 @@
+# Container Images
+
+This document describes the container image tags used by this repository and
+how they relate to runtime presets and Git history.
+
+The top-level README only lists the current recommended runtime paths. This
+document provides the detailed image-tag history.
+
+## Current recommended paths
+
+| Path | Status | Config | Image source |
+|---|---|---|---|
+| `dsv4-d568` | Frozen primary DeepSeek-V4-Flash baseline | `presets/dsv4-flash-fp8-tp2.env` | `ghcr.io/bjk110/vllm-spark:dsv4-d568` — see the image mapping below |
+| `unholy-fusion` | Experimental high-prefill path | `.env.unholy-fusion` + `compose/docker-compose.unholy.yml` | External/upstream image (`aidendle94/sparkrun-vllm-ds4-gb10:production-ready`) or its GHCR mirror — see `docs/repository-status.md` |
+
+## Image tag mapping
+
+GHCR image tags (`ghcr.io/bjk110/vllm-spark:<tag>`) and Git tags do **not**
+march in lockstep yet — only `v018-ngc2603` exists as a Git tag. The mapping
+below documents what each image tag corresponds to in the Git history. Use
+this table when you need to reproduce or roll back to a specific image.
+
+| Image tag | Git ref (commit) | Stack | Notes |
+|---|---|---|---|
+| `dsv4-d568` (active, DSV4-specific) | repository HEAD at the time this mapping was last reviewed | `FROM v022-d568` + SM12x DSV4 vLLM patches | DeepSeek-V4-Flash primary path; used only by `presets/dsv4-flash-fp8-tp2.env`. See [`docs/dsv4-flash-tp2.md`](dsv4-flash-tp2.md). **Frozen** — see `docs/repository-status.md` directory-roles table. |
+| `v022-d568` (active, general base) | repository HEAD at the time this mapping was last reviewed | NGC 26.04 + vLLM 0.21.0+PR#35568 + FlashInfer 0.6.11.post3 + Triton 3.7.0 + NCCL 2.30.4 + Transformers 5.8.1 | Forward-stack validation base for v022-series presets and the dsv4-d568 derivative. |
+| `v021-tq` | `3070f9a` | base + TQ patches + Inductor-graph-partition fix | Required for any `*-tq.env` preset (legacy preset base for TurboQuant presets). |
+| `v021-ngc2603` | `8623187` | vLLM `95995bbe` + FlashInfer `v0.6.9` | Retained for older presets — most non-TQ `presets/*.env` files reference this. |
+| `v020-ngc2603` (superseded) | `8efdf0b` (base-refresh-20260417 base bump) | vLLM `978a4462` + FlashInfer `v0.6.8` | Superseded by v021; only kept on GHCR for historical reproduction. |
+| `v019-ngc2603` (superseded) | `7736716` (Gemma 4 + vLLM 0.19.1 upgrade) | vLLM `0.19.1` `a7d79fa` + FlashInfer `v0.6.7.post3` | Superseded by v021. |
+| `v018-ngc2603` (archive) | `feb5993` (NGC 26.03 source build intro) — Git tag `v018-ngc2603` exists | vLLM `0.18.3` `c494977` + FlashInfer `v0.6.7` | The only currently-tagged release in Git. |
+
+## Notes
+
+- GHCR image tags and Git tags may not always move in lockstep.
+- Prefer release notes and image digests when exact image reproducibility
+  matters — see this repository's GitHub Releases for independently verified
+  digests.
+- Some older tags are retained for historical reproduction only.
+- Do not infer current recommended runtime settings from raw image tags alone.
+- For maintainer-only Git tag creation and archived branch notes, see
+  [`docs/release-management.md`](release-management.md).

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -1,0 +1,61 @@
+# Release Management Notes
+
+This document collects maintainer-oriented notes for Git tags, GHCR image
+tags, and archived branch references.
+
+It is not required for normal users who only want to run the published
+containers.
+
+## Git tags and GHCR image tags
+
+GHCR image tags and Git tags do not necessarily move in lockstep — only
+`v018-ngc2603` currently exists as a Git tag.
+
+For user-facing image and preset mapping, see [`docs/images.md`](images.md).
+
+## Recommended Git tags to create
+
+> **Maintainer-only.** Do not run these commands blindly: verify the commit
+> SHAs against the current `git log` first, confirm the corresponding GHCR
+> image exists, and do not overwrite existing tags.
+
+The maintainer can create the following tags to align Git tags with GHCR
+image tags. Run from a clean checkout of `main`.
+
+    git tag -a v019-ngc2603 7736716 -m "v019-ngc2603 — Gemma 4 + vLLM 0.19.1"
+    git tag -a v020-ngc2603 8efdf0b -m "v020-ngc2603 — base-refresh-20260417 (vLLM 978a4462, FlashInfer 0.6.8)"
+    git tag -a v021-ngc2603 8623187 -m "v021-ngc2603 — vLLM 95995bbe + FlashInfer v0.6.9"
+    git tag -a v021-tq      3070f9a -m "v021-tq — base + TurboQuant cherry-picks + codegen workaround"
+    git push origin v019-ngc2603 v020-ngc2603 v021-ngc2603 v021-tq
+
+**Verify commit before tagging.** The four SHAs above were extracted from
+`git log --oneline` at the time this document was last updated; if subsequent
+work reshuffles `main`, re-locate the boundary commits with:
+
+    git log --oneline --grep='base.refresh\|bump base.*v021\|0.19.1\|use Inductor graph partition'
+
+Before creating tags:
+
+1. Verify the commit SHA.
+2. Confirm the corresponding GHCR image exists.
+3. Confirm the image digest if reproducibility matters.
+4. Do not overwrite existing tags.
+
+## Branch structure
+
+`main` is the only long-lived branch. All previously separate work
+streams (base stack refresh, TurboQuant rebase, single-Spark CLUSTER_MODE,
+unholy-fusion integration) have been merged in and their feature branches
+deleted.
+
+## Archived branch history
+
+The legacy TurboQuant branch is preserved as a tag for reference:
+
+- **`archive/feat-turboquant`**
+
+If needed, it can be restored with:
+
+```bash
+git checkout -b feat/turboquant archive/feat-turboquant
+```

--- a/docs/repository-status.md
+++ b/docs/repository-status.md
@@ -1,6 +1,6 @@
 # Repository Status and Cleanup Roadmap
 
-Last updated: 2026-06-07 (Stage 3-G).
+Last updated: 2026-06-07 (Stage 3-H).
 
 This document summarises the current recommended paths, major directory roles,
 completed documentation cleanup stages, and intentionally deferred structural work.
@@ -81,6 +81,8 @@ benchmark traceability. `jasl` is not a currently recommended operational path.
 | `benchmarks/llama-benchy/` | Raw llama-benchy output files; filename legend in `benchmarks/llama-benchy/README.md` |
 | `docs/unholy-fusion-benchmark.md` | Interpreted unholy-fusion serving result analysis and DSV4 comparison |
 | `docs/model-serving-validation-history.md` | Historical stack validation notes and benchmark results (Gemma 4, Qwen3.5 122B, 397B INT4, PrismaQuant, TurboQuant KV sweep) — extracted from `README.md` |
+| `docs/images.md` | Container image tag history and image-to-preset/Git-ref mapping — extracted from `README.md` |
+| `docs/release-management.md` | Maintainer-only Git tag creation, branch structure, and archived branch notes — extracted from `README.md` |
 | `entrypoints/` | Container entrypoint scripts; selected via `ENTRYPOINT_FILE` in `docker-compose.yml`; see `entrypoints/README.md` |
 | `compose/` | Compose overrides (`docker-compose.unholy.yml`); referenced via `-f` flag |
 | `docs/` | Interpreted technical notes, stack guides, and status documents |
@@ -105,6 +107,7 @@ benchmark traceability. `jasl` is not a currently recommended operational path.
 | **Stage 3-E** | Benchmark folder scope clarified as raw artifacts only; interpreted benchmark analysis confirmed to remain under `docs/`; `benchmarks/README.md` updated to remove safe-default guidance and point to `docs/unholy-fusion-benchmark.md`. |
 | **Stage 3-F** | Detailed v022 stack validation notes and historical benchmark tables (Gemma 4, Qwen3.5 122B, 397B INT4, PrismaQuant, TurboQuant KV sweep) extracted from `README.md` into `docs/model-serving-validation-history.md`; `README.md` replaced with concise summaries and links. |
 | **Stage 3-G** | Out-of-scope quantization utility (`quantize/`) removed from this serving repository and kept out of scope; quantization tooling is intentionally not part of this repo's focus on DGX Spark / GB10 vLLM container serving. |
+| **Stage 3-H** | README image/Git tag management details extracted into `docs/images.md` and `docs/release-management.md`; `README.md` replaced with a concise current-paths summary and links (docs-only — no runtime, image, or tag changes). |
 
 ---
 


### PR DESCRIPTION
## Summary

This PR moves detailed image-tag / Git-tag / branch-history management content out of the top-level `README.md` into two dedicated docs, leaving a concise public-facing summary in the README.

## Why

- README should focus on public user onboarding and current runtime paths, not maintainer-only Git operations.
- `git tag -a ...` / `git push origin ...` are maintainer-only commands that don't belong in first-user guidance.
- "current HEAD" mappings go stale quickly; "production default" wording for older images conflicted with the current recommended-path guidance.
- Archived branch recovery instructions are history/maintainer material, not onboarding content.

## Changes

- Added `docs/images.md`: current recommended paths summary + the full image-tag ↔ Git-ref mapping table (tag names, commit SHAs, stack descriptions, and notes preserved verbatim). Reworded "current HEAD" → "repository HEAD at the time this mapping was last reviewed" and "production default" → "legacy preset base" / "retained for older presets" to avoid staleness and recommended-path confusion. `dsv4-d568` kept marked **frozen**, `unholy-fusion` kept marked **experimental**.
- Added `docs/release-management.md`: maintainer-only home for "Recommended Git tags to create" (all `git tag -a` / `git push origin` commands preserved verbatim), "Branch structure", and "Archived branch history" (`archive/feat-turboquant` + restore command preserved). Added an explicit maintainer-only warning (verify SHAs, confirm GHCR image exists, do not overwrite tags).
- `README.md`: replaced the long "Image tags & Git tags" / "Branch structure" / "Archived branch history" section with a concise "Container images" section (current recommended paths table) plus links to the two new docs.
- `docs/repository-status.md`: added directory-role entries for the two new docs and a Stage 3-H cleanup record, following the file's existing style.

## Validation

- No Dockerfile, Compose, entrypoint, patch, preset, benchmark, env value, or image tag/digest changes
- No Git tags created or pushed; no GitHub Releases modified
- `bash -n` passed for both entrypoint scripts
- Docker Compose config parsed for normal and unholy-fusion paths
- Maintainer-only commands (`git tag -a`, `git push origin`, archived-branch restore) now exist only in `docs/release-management.md`

## Notes

This is a documentation-only reorganization — no runtime behavior, image tags, digests, or release artifacts change.
