### PR TITLE
fix: sanitize empty optional env vars and pin NVFP4/GB10 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ vllm-spark/
 └── scripts/
     ├── run-cluster-node.sh        # Manual Ray cluster bootstrap
     ├── verify_imports.py          # Build-time import verification
-    └── verify_runtime.sh          # Full GPU verification
+    ├── verify_runtime.sh          # Full GPU verification
+    └── check-empty-env.sh         # Lint presets for empty optional env vars (issue #14)
 ```
 
 ## Architecture

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,63 @@ can't bind to a RoCE IP that doesn't exist on this host. Fix:
    `CLUSTER_MODE=single: VLLM_HOST_IP=127.0.0.1, NCCL_IB_DISABLE=1, NCCL/GLOO/UCX ifname cleared`
    on a clean single-Spark start.
 
+## Empty optional env vars (`${VAR:-}` defaults, issue #14)
+
+`docker-compose.yml` forwards many optional knobs into the container as
+`${VAR:-}`. If a preset doesn't set `VAR`, the container still gets
+`VAR=""` — an env var that is **set to an empty string**, not unset. Some
+vLLM / FlashInfer / Triton-DG env parsers treat those very differently from a
+truly-unset var:
+
+- `VLLM_NVFP4_GEMM_BACKEND=""` → `ValueError: Invalid value '' for
+  VLLM_NVFP4_GEMM_BACKEND` (enum-validated env var)
+- `FLASHINFER_CUDA_ARCH_LIST=""` → `flashinfer/compilation_context.py` does
+  `arch.split(".")` → `ValueError: not enough values to unpack (expected 2,
+  got 1)`
+- `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=""` → `invalid literal for int()
+  with base 10: ''`, which can leave CUDA-graph capture under-provisioned and
+  the EngineCore gets OOM-killed during graph capture
+
+**Fix (already applied as of this writing — pull latest `main`):**
+`entrypoints/entrypoint.sh` runs `unset_empty_optional_envs()` at startup,
+before anything else, and `unset`s any of ~24 known optional env vars
+(`VLLM_NVFP4_GEMM_BACKEND`, `VLLM_ATTENTION_BACKEND`,
+`VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS`, `FLASHINFER_CUDA_ARCH_LIST`,
+`TORCH_CUDA_ARCH_LIST`, the B12X/NCCL/DG-JIT toggles, etc.) if they were
+forwarded as an empty string. This makes vLLM/FlashInfer fall back to their
+normal "unset" defaults instead of crashing on `""`. If you're still hitting
+one of the errors above, confirm your image's `/entrypoint.sh` actually
+contains `unset_empty_optional_envs` (older images baked the entrypoint in,
+so a `docker compose pull`/restart with an old image won't pick up a `main`
+fix — rebuild or bind-mount the updated `entrypoints/entrypoint.sh`).
+
+**NVFP4 on GB10/sm_121 — pin explicit values, don't rely on defaults:**
+presets that pass `--quantization nvfp4` (runtime NVFP4, e.g.
+`qwen3.5-122b-nvfp4*.env`) genuinely exercise the FlashInfer NVFP4 GEMM and
+CUDA-graph profiling paths, so set these explicitly rather than letting the
+sanitizer unset them:
+
+```bash
+VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
+FLASHINFER_CUDA_ARCH_LIST=12.1
+TORCH_CUDA_ARCH_LIST=12.1a
+VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1
+```
+
+**Diagnostic command** — render the final env that a preset produces (after
+`${VAR:-}` substitution) without starting a container:
+
+```bash
+MODEL_PATH=/tmp docker compose --env-file presets/<preset>.env --profile head config \
+  | grep -E "VLLM_NVFP4_GEMM_BACKEND|VLLM_ATTENTION_BACKEND|FLASHINFER_CUDA_ARCH_LIST|TORCH_CUDA_ARCH_LIST|VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS"
+```
+
+A value of `""` here is fine for the entrypoint sanitizer to handle, but for
+NVFP4 presets it should instead show the explicit values above. Run
+`bash scripts/check-empty-env.sh` to check all presets at once — it fails
+only if a runtime-NVFP4 preset is missing one of the four pins, and prints
+informational notes for everything else.
+
 ## Model path and preset issues
 
 - `MODEL_PATH` must point to a local model-weight directory — `presets/*.env`

--- a/entrypoints/entrypoint.sh
+++ b/entrypoints/entrypoint.sh
@@ -1,6 +1,54 @@
 #!/bin/bash
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Empty optional env var sanitizer
+# ---------------------------------------------------------------------------
+# docker-compose.yml forwards many optional knobs as `${VAR:-}`, so a preset
+# that doesn't set VAR results in VAR being *set to an empty string* in the
+# container, not unset. Some vLLM / FlashInfer / Triton-DG env parsers treat
+# "set to empty string" differently from "unset" -- e.g. an enum-validated
+# env var raises `ValueError: Invalid value '' for VLLM_NVFP4_GEMM_BACKEND`,
+# or `flashinfer/compilation_context.py` does `arch.split(".")` on an empty
+# FLASHINFER_CUDA_ARCH_LIST and raises `ValueError: not enough values to
+# unpack`. Unset these vars when empty so vLLM/FlashInfer fall back to their
+# normal "unset" defaults. See GitHub issue #14.
+unset_empty_optional_envs() {
+    local name
+    for name in "$@"; do
+        if [ -n "${!name+x}" ] && [ -z "${!name}" ]; then
+            echo "[entrypoint] Unsetting empty optional env: ${name}"
+            unset "${name}"
+        fi
+    done
+}
+
+unset_empty_optional_envs \
+    VLLM_NVFP4_GEMM_BACKEND \
+    VLLM_ATTENTION_BACKEND \
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS \
+    VLLM_USE_BREAKABLE_CUDAGRAPH \
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN \
+    VLLM_TRITON_MLA_SPARSE \
+    FLASHINFER_CUDA_ARCH_LIST \
+    FLASHINFER_DISABLE_VERSION_CHECK \
+    TORCH_CUDA_ARCH_LIST \
+    TILELANG_CLEANUP_TEMP_FILES \
+    DG_JIT_USE_NVRTC \
+    DG_JIT_NVCC_COMPILER \
+    DG_JIT_PRINT_COMPILER_COMMAND \
+    VLLM_USE_B12X_MOE \
+    VLLM_USE_B12X_MHC \
+    VLLM_USE_B12X_FP8_GEMM \
+    VLLM_USE_B12X_SPARSE_INDEXER \
+    VLLM_USE_B12X_WO_PROJECTION \
+    NCCL_NET \
+    NCCL_CUMEM_ENABLE \
+    NCCL_CROSS_NIC \
+    NCCL_IGNORE_CPU_AFFINITY \
+    VLLM_NCCL_SO_PATH \
+    VLLM_CACHE_ROOT
+
 # Apply Qwen3.5 MoE text-only patches (abliterated models only)
 # Set APPLY_TEXT_ONLY_SHIM=1 in .env to enable
 if [ "${APPLY_TEXT_ONLY_SHIM:-0}" = "1" ] && [ -f /patches/qwen/patch_qwen35_moe_text.py ]; then

--- a/presets/qwen3.5-122b-nvfp4-tp2.env
+++ b/presets/qwen3.5-122b-nvfp4-tp2.env
@@ -1,5 +1,12 @@
 # =============================================================================
 # Qwen3.5-122B-A10B NVFP4 — TP2 Multi-Node
+#
+# This preset performs RUNTIME NVFP4 quantization (--quantization nvfp4) of
+# the original BF16 Qwen/Qwen3.5-122B-A10B checkpoint at load time. For a
+# PRE-QUANTIZED NVFP4 checkpoint (e.g. RedHatAI/txn545 compressed-tensors
+# nvfp4-pack-quantized releases, where quantization is auto-detected from the
+# checkpoint config and no --quantization flag is needed), see
+# redhatai-122b-nvfp4.env instead.
 # =============================================================================
 
 # ---- Image ----
@@ -27,8 +34,20 @@ GPU_MEMORY_UTILIZATION=0.90
 MAX_NUM_BATCHED_TOKENS=16384
 
 # ---- Extra args ----
-VLLM_EXTRA_ARGS=--quantization nvfp4 --kv-cache-dtype fp8 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder
+# --compilation-config use_inductor_graph_partition=true works around a
+# torch.compile codegen SyntaxError for this model's GDN/Mamba hybrid layers
+# (see README.md "Troubleshooting" -> "SyntaxError: invalid syntax in
+# compilation/codegen.py", issue #14).
+VLLM_EXTRA_ARGS=--quantization nvfp4 --kv-cache-dtype fp8 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --compilation-config {"use_inductor_graph_partition":true}
 
 # ---- Model-specific env vars ----
 VLLM_MARLIN_USE_ATOMIC_ADD=0
 VLLM_USE_FLASHINFER_MOE_FP4=1
+# NVFP4 GEMM backend + FlashInfer/Triton-DG arch list. These have empty
+# defaults in docker-compose.yml; entrypoint.sh now unsets them when empty
+# (issue #14), but pin explicit values here since this preset's
+# --quantization nvfp4 path does exercise the NVFP4 GEMM/FlashInfer code.
+VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
+FLASHINFER_CUDA_ARCH_LIST=12.1
+TORCH_CUDA_ARCH_LIST=12.1a
+VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1

--- a/presets/qwen3.5-122b-nvfp4.env
+++ b/presets/qwen3.5-122b-nvfp4.env
@@ -1,5 +1,12 @@
 # =============================================================================
 # Qwen3.5-122B-A10B NVFP4 — TP1 Single-Node
+#
+# This preset performs RUNTIME NVFP4 quantization (--quantization nvfp4) of
+# the original BF16 Qwen/Qwen3.5-122B-A10B checkpoint at load time. For a
+# PRE-QUANTIZED NVFP4 checkpoint (e.g. RedHatAI/txn545 compressed-tensors
+# nvfp4-pack-quantized releases, where quantization is auto-detected from the
+# checkpoint config and no --quantization flag is needed), see
+# redhatai-122b-nvfp4.env instead.
 # =============================================================================
 
 # ---- Image ----
@@ -23,12 +30,26 @@ TP_SIZE=1
 HOST_PORT=8000
 MAX_MODEL_LEN=32768
 MAX_NUM_SEQS=8
-GPU_MEMORY_UTILIZATION=0.90
+# 0.90 leaves too little headroom for weight load + torch.compile on a single
+# GB10 (swap-thrash); 0.80 is stable (issue #14).
+GPU_MEMORY_UTILIZATION=0.80
 MAX_NUM_BATCHED_TOKENS=16384
 
 # ---- Extra args ----
-VLLM_EXTRA_ARGS=--quantization nvfp4 --kv-cache-dtype fp8 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder
+# --compilation-config use_inductor_graph_partition=true works around a
+# torch.compile codegen SyntaxError for this model's GDN/Mamba hybrid layers
+# (see README.md "Troubleshooting" -> "SyntaxError: invalid syntax in
+# compilation/codegen.py", issue #14).
+VLLM_EXTRA_ARGS=--quantization nvfp4 --kv-cache-dtype fp8 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --compilation-config {"use_inductor_graph_partition":true}
 
 # ---- Model-specific env vars ----
 VLLM_MARLIN_USE_ATOMIC_ADD=0
 VLLM_USE_FLASHINFER_MOE_FP4=1
+# NVFP4 GEMM backend + FlashInfer/Triton-DG arch list. These have empty
+# defaults in docker-compose.yml; entrypoint.sh now unsets them when empty
+# (issue #14), but pin explicit values here since this preset's
+# --quantization nvfp4 path does exercise the NVFP4 GEMM/FlashInfer code.
+VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
+FLASHINFER_CUDA_ARCH_LIST=12.1
+TORCH_CUDA_ARCH_LIST=12.1a
+VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1

--- a/presets/qwen3.6-27b-base-bf16-tp2.env
+++ b/presets/qwen3.6-27b-base-bf16-tp2.env
@@ -58,7 +58,6 @@ VLLM_EXTRA_ARGS=--kv-cache-dtype fp8 --enable-chunked-prefill --reasoning-parser
 # ---- Runtime env ----
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
-# ---- Quant-backend toggles (all 0 since BF16) ----
-VLLM_NVFP4_GEMM_BACKEND=
+# ---- Quant-backend toggles (0 since BF16) ----
 VLLM_MARLIN_USE_ATOMIC_ADD=0
 VLLM_USE_FLASHINFER_MOE_FP4=0

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-d568.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-d568.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-fi0611.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-fi0611.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-nccl234.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-nccl234.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-ngc2604.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-ngc2604.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-trt37.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-trt37.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-tx581.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022-tx581.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2-v022.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -46,8 +47,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/qwen3.6-27b-prismascout-nvfp4-tp2.env
+++ b/presets/qwen3.6-27b-prismascout-nvfp4-tp2.env
@@ -6,9 +6,10 @@
 # Speculative decoding: MTP n=3 (default for this preset). DFlash is a documented
 # experimental swap-in, see README.md (Supported Models).
 #
-# This preset is consumed by docker-compose.yml, which
-# also passes VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass through to the
-# container (the shared docker-compose.yml does not pipe that var through).
+# This preset sets VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass, which the
+# shared docker-compose.yml passes through to the container as
+# ${VLLM_NVFP4_GEMM_BACKEND:-} (entrypoint.sh unsets it if ever empty, see
+# issue #14).
 # =============================================================================
 
 # ---- Image ----
@@ -48,8 +49,8 @@ VLLM_EXTRA_ARGS=--quantization compressed-tensors --kv-cache-dtype fp8 --enable-
 
 # ---- Model-specific env vars ----
 # NVFP4 GEMM backend: flashinfer-cutlass (PrismaSCOUT 권장).
-# 이 변수는 shared docker-compose.yml 에는 없고, 본 preset 전용
-# docker-compose.yml 에서 컨테이너로 전달됩니다.
+# shared docker-compose.yml이 ${VLLM_NVFP4_GEMM_BACKEND:-}로 컨테이너에
+# 전달하며, 비어있을 경우 entrypoint.sh가 unset 처리합니다 (issue #14).
 VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 

--- a/presets/redhatai-122b-nvfp4.env
+++ b/presets/redhatai-122b-nvfp4.env
@@ -1,6 +1,11 @@
 # =============================================================================
 # RedHatAI Qwen3.5-122B-A10B-NVFP4 — TP1 Single-Node
-# Pre-quantized NVFP4 checkpoint (compressed-tensors, nvfp4-pack-quantized)
+# Pre-quantized NVFP4 checkpoint (compressed-tensors, nvfp4-pack-quantized).
+# Quantization is auto-detected from the checkpoint config -- no
+# --quantization flag needed. Other pre-quantized NVFP4 releases of the same
+# base model (e.g. txn545/Qwen3.5-122B-A10B-NVFP4, see issue #14) follow the
+# same pattern. For RUNTIME NVFP4 quantization of the original BF16 weights
+# instead, see qwen3.5-122b-nvfp4.env.
 # =============================================================================
 
 # ---- Image ----

--- a/presets/step37-flash-fp8-tp2.env
+++ b/presets/step37-flash-fp8-tp2.env
@@ -70,9 +70,3 @@ VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1
 FLASHINFER_CUDA_ARCH_LIST=12.1
 VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0
 VLLM_NCCL_SO_PATH=/usr/lib/aarch64-linux-gnu/libnccl.so.2
-
-# Required non-empty default: docker-compose.yml's VLLM_NVFP4_GEMM_BACKEND:-
-# falls back to "" which vLLM 0.22.1 rejects with ValueError at startup even
-# for non-NVFP4 models. "cutlass" is a no-op for this FP8 model.
-VLLM_NVFP4_GEMM_BACKEND=cutlass
-VLLM_ATTENTION_BACKEND=

--- a/scripts/check-empty-env.sh
+++ b/scripts/check-empty-env.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# =============================================================================
+# check-empty-env.sh
+#
+# Lint presets/*.env against docker-compose.yml's `${VAR:-}` substitutions.
+#
+# entrypoints/entrypoint.sh now unsets any of these vars when docker-compose
+# renders them as an empty string ("VAR=" -> unset), so a plain empty value is
+# no longer a hard crash for any preset (see issue #14). However, NVFP4
+# presets (--quantization nvfp4 / VLLM_USE_FLASHINFER_MOE_FP4=1) genuinely
+# need explicit values for the FlashInfer/Triton-DG/CUDA-graph knobs below --
+# if those render empty, the NVFP4 GEMM/attention/CUDA-graph paths fall back
+# to upstream defaults that are not validated on GB10/sm_121.
+#
+# This script fails (exit 1) only when an NVFP4-sensitive preset is missing
+# one of those explicit values. For all other presets it just reports which
+# optional vars are empty (informational; entrypoint.sh sanitizes them).
+# =============================================================================
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[check-empty-env] docker not found, skipping" >&2
+    exit 0
+fi
+
+# Vars that have an empty `${VAR:-}` default in docker-compose.yml and that
+# NVFP4 presets must pin to a real value (see entrypoint.sh sanitizer list
+# and issue #14).
+NVFP4_REQUIRED_VARS=(
+    VLLM_NVFP4_GEMM_BACKEND
+    FLASHINFER_CUDA_ARCH_LIST
+    TORCH_CUDA_ARCH_LIST
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+)
+
+# Other optional vars worth reporting on (sanitized when empty, never fatal).
+INFO_VARS=(
+    VLLM_ATTENTION_BACKEND
+)
+
+fail=0
+
+for preset in presets/*.env; do
+    name=$(basename "$preset")
+
+    config_out=$(MODEL_PATH=/tmp ENTRYPOINT_FILE=./entrypoints/entrypoint.sh \
+        docker compose --env-file "$preset" --profile head config 2>/dev/null) || {
+        echo "[check-empty-env] WARN ${name}: docker compose config failed, skipping" >&2
+        continue
+    }
+
+    # Only flag presets that perform RUNTIME NVFP4 quantization
+    # (--quantization nvfp4). Pre-quantized compressed-tensors/modelopt NVFP4
+    # checkpoints (redhatai-*, wangzhang-*-nvfp4*, prismascout-*) use a
+    # different quant path and are documented as verified-working without
+    # these pins -- don't fail the lint for those.
+    is_nvfp4=0
+    if grep -qiE -- '--quantization[[:space:]]+nvfp4' "$preset"; then
+        is_nvfp4=1
+    fi
+
+    for var in "${NVFP4_REQUIRED_VARS[@]}"; do
+        value=$(echo "$config_out" | grep -E "^\s*${var}:" | head -1 | sed -E 's/^[^:]*:\s*//')
+        if [ "$value" = '""' ] || [ -z "$value" ]; then
+            if [ "$is_nvfp4" -eq 1 ]; then
+                echo "[check-empty-env] ERROR ${name}: ${var} is empty in an NVFP4 preset"
+                fail=1
+            else
+                echo "[check-empty-env] info ${name}: ${var} empty (sanitized by entrypoint.sh)"
+            fi
+        fi
+    done
+
+    for var in "${INFO_VARS[@]}"; do
+        value=$(echo "$config_out" | grep -E "^\s*${var}:" | head -1 | sed -E 's/^[^:]*:\s*//')
+        if [ "$value" = '""' ] || [ -z "$value" ]; then
+            echo "[check-empty-env] info ${name}: ${var} empty (sanitized by entrypoint.sh)"
+        fi
+    done
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "[check-empty-env] FAILED: NVFP4 preset(s) missing required env values" >&2
+    exit 1
+fi
+
+echo "[check-empty-env] OK"


### PR DESCRIPTION
## Summary
- Closes #14: `qwen3.5-122b-nvfp4.env` (single-node TP1) was missing several env vars that docker-compose forwards as `${VAR:-}` (i.e. as an empty string, not unset), causing a chain of startup crashes (`VLLM_NVFP4_GEMM_BACKEND`, `FLASHINFER_CUDA_ARCH_LIST`, `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS`, plus a `--compilation-config` codegen `SyntaxError` and a swap-thrash from `GPU_MEMORY_UTILIZATION=0.90`).
- Root-cause fix: `entrypoints/entrypoint.sh` now runs `unset_empty_optional_envs()` first thing, unsetting ~24 known optional env vars whenever docker-compose forwarded them as `""` so vLLM/FlashInfer fall back to their normal unset-defaults instead of crashing.
- `qwen3.5-122b-nvfp4.env` / `-tp2.env`: add `--compilation-config {"use_inductor_graph_partition":true}`, pin `VLLM_NVFP4_GEMM_BACKEND=flashinfer-cutlass`, `FLASHINFER_CUDA_ARCH_LIST=12.1`, `TORCH_CUDA_ARCH_LIST=12.1a`, `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1` for GB10/sm_121, and lower single-node `GPU_MEMORY_UTILIZATION` 0.90 → 0.80.
- Cleaned up two presets (`qwen3.6-27b-base-bf16-tp2.env`, `step37-flash-fp8-tp2.env`) that had redundant empty-string env assignments now handled generally by the sanitizer.
- Fixed stale comments in 8 PrismaSCOUT NVFP4 preset variants claiming the shared `docker-compose.yml` doesn't pass `VLLM_NVFP4_GEMM_BACKEND` through (it does).
- Added cross-reference comments clarifying runtime NVFP4 quantization (`qwen3.5-122b-nvfp4*.env`) vs pre-quantized compressed-tensors checkpoints (`redhatai-122b-nvfp4.env`, e.g. txn545-style releases).
- New `scripts/check-empty-env.sh` lint: renders `docker compose config` per preset, fails only if a runtime `--quantization nvfp4` preset is missing one of the GB10 pins above (informational for everything else).
- Documented the empty-vs-unset env var issue, the sanitizer, NVFP4 GB10 pins, and the diagnostic command in `docs/troubleshooting.md` (linked from README).

## Test plan
- [x] `bash -n entrypoints/entrypoint.sh`
- [x] `bash scripts/check-empty-env.sh` → OK (exit 0)
- [x] `docker compose --env-file presets/qwen3.5-122b-nvfp4.env --profile head config` — confirms NVFP4 pins + `--compilation-config` render correctly
- [x] `docker compose --env-file presets/qwen3.5-122b-nvfp4-tp2.env --profile head config` — same
- [x] `docker compose --env-file presets/step37-flash-fp8-tp2.env --profile head config` — confirms removed empty assignments no longer present
- [x] `docker compose --env-file presets/qwen3.6-27b-base-bf16-tp2.env --profile head config` — confirms removed empty `VLLM_NVFP4_GEMM_BACKEND=` no longer present
- [ ] Live boot test of `qwen3.5-122b-nvfp4.env` on a GB10 Spark (not run in this session — no spare node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)